### PR TITLE
Make isPrefixOf non-symmetrical

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1084,8 +1084,8 @@ selectSplit xs =
 {-| Take 2 lists and return True, if the first list is the prefix of the second list.
 -}
 isPrefixOf : List a -> List a -> Bool
-isPrefixOf prefix =
-    all identity << map2 (==) prefix
+isPrefixOf prefix xs =
+    List.length prefix <= List.length xs && all identity (map2 (==) prefix xs)
 
 
 {-| Take 2 lists and return True, if the first list is the suffix of the second list.


### PR DESCRIPTION
Because `map2` discards extra elements in either of its list parameters, the previous implementation functions as "either is prefix of the other", not as "first is prefix of second".

I think fixing this behaviour constitutes a breaking change?